### PR TITLE
revisions per CakePHP Plugin naming deprecation

### DIFF
--- a/src/HCaptchaPlugin.php
+++ b/src/HCaptchaPlugin.php
@@ -8,11 +8,11 @@ use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 
 /**
- * Class Plugin
+ * Class HCaptchaPlugin
  *
  * @package HCaptcha
  */
-class Plugin extends BasePlugin
+class HCaptchaPlugin extends BasePlugin
 {
     /**
      * Initialize plugin.


### PR DESCRIPTION
https://book.cakephp.org/5.x/appendices/5-3-migration-guide.html#plugin

- renamed file Plugin.php to HCaptchaPlugin.php
- renamed class Plugin to HCaptchaPlugin